### PR TITLE
Front/feature/auth 로그인 및 로그인 관련 api, utile 구현

### DIFF
--- a/client/src/api/auth.api.ts
+++ b/client/src/api/auth.api.ts
@@ -1,0 +1,14 @@
+import { Axios } from './base.api';
+
+export const postUserLogin = async ({ email, password }: { email: string; password: string }) => {
+  const { data } = await Axios.post('/v1/auth/login', {
+    email,
+    password,
+  });
+  return data;
+};
+
+export const getRecruit = (id: string) => {
+  const url = `/v1/recruits/${id}`;
+  return Axios(url).then((res) => res.data);
+};

--- a/client/src/api/base.api.ts
+++ b/client/src/api/base.api.ts
@@ -1,3 +1,4 @@
+import { formatCustomError } from '@/utils/errorHandling';
 import axios from 'axios';
 
 const BASE_URL = 'http://localhost:3000/api';
@@ -22,6 +23,10 @@ Axios.interceptors.request.use(
 // Add a response interceptor
 Axios.interceptors.response.use(
   function (response) {
+    // response.data.success가 false인 값을 에러 형태로 바꿔준다.
+    if (response.data.success === false) {
+      return formatCustomError(response);
+    }
     return response;
   },
   function (error) {

--- a/client/src/components/auth/LoginModal.tsx
+++ b/client/src/components/auth/LoginModal.tsx
@@ -1,3 +1,5 @@
+import { postUserLogin } from '@/api/auth.api';
+import { Link } from '@mui/material';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -5,6 +7,10 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
+import { AxiosError } from 'axios';
+import { ChangeEventHandler, FormEventHandler, useState } from 'react';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 
 interface LoginModalProps {
   isOpen: boolean;
@@ -12,6 +18,41 @@ interface LoginModalProps {
 }
 
 export default function LoginModal({ isOpen, onClose }: LoginModalProps) {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
+  const [formErrors, setFormErrors] = useState({
+    email: '',
+    password: '',
+  });
+
+  const { mutate, isError } = useMutation(postUserLogin, {
+    onSuccess: (data) => {
+      if (!data.data.token) {
+        throw new Error('토큰을 받아오지 못하였습니다.');
+      }
+      sessionStorage.setItem('token', data.data.token);
+      navigate('/home');
+    },
+    onError: (error: AxiosError) => {
+      const { message } = error;
+      if (message === '존재하지 않는 아이디입니다.') setFormErrors({ email: message, password: '' });
+      else setFormErrors({ email: '', password: message });
+    },
+  });
+
+  const handleChangeInput: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { id, value } = e.target;
+    setFormData((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleSubmitLogin: FormEventHandler = (e) => {
+    e.preventDefault();
+    mutate(formData);
+  };
+
   const handleClose = (isSuccess: boolean = false) => {
     if (typeof onClose === 'function') onClose(isSuccess);
   };
@@ -19,40 +60,60 @@ export default function LoginModal({ isOpen, onClose }: LoginModalProps) {
   return (
     <div>
       <Dialog open={isOpen}>
-        <DialogTitle>로그인</DialogTitle>
-        <DialogContent>
-          <TextField
-            autoFocus
-            fullWidth
-            margin="dense"
-            id="email"
-            label="이메일 주소"
-            type="email"
-            variant="standard"
-          />
+        <form onSubmit={handleSubmitLogin}>
+          <DialogTitle>로그인</DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              fullWidth
+              margin="dense"
+              id="email"
+              type="email"
+              label="이메일 주소"
+              variant="standard"
+              autoComplete="email"
+              value={formData.email}
+              onChange={handleChangeInput}
+              error={isError}
+              helperText={formErrors.email}
+              required
+            />
 
-          <TextField
-            fullWidth
-            margin="dense"
-            id="password"
-            label="비밀번호"
-            type="password"
-            variant="standard"
-          />
+            <TextField
+              fullWidth
+              margin="dense"
+              id="password"
+              label="비밀번호"
+              type="password"
+              variant="standard"
+              value={formData.password}
+              onChange={handleChangeInput}
+              error={isError}
+              helperText={formErrors.password}
+              required
+            />
 
-          <DialogContentText>
-            <small>
-              계정이 없으신가요? <span className="link">회원가입하러 가기</span>
-            </small>
-          </DialogContentText>
-        </DialogContent>
+            <DialogContentText>
+              <small>
+                계정이 없으신가요?{' '}
+                <Link
+                  onClick={() => navigate('/register')}
+                  component="button"
+                  sx={{ color: 'inherit', textDecorationColor: 'inherit', fontWeight: 500, verticalAlign: 'baseline' }}
+                >
+                  회원가입하러 가기
+                </Link>
+              </small>
+            </DialogContentText>
+          </DialogContent>
 
-        <DialogActions>
-          <Button color="error" onClick={() => handleClose(false)}>
-            취소
-          </Button>
-          <Button>로그인</Button>
-        </DialogActions>
+          <DialogActions>
+            <Button color="error" onClick={() => handleClose(false)}>
+              취소
+            </Button>
+            <Button type="submit">로그인</Button>
+          </DialogActions>
+        </form>
       </Dialog>
     </div>
   );

--- a/client/src/components/auth/RegisterModal.tsx
+++ b/client/src/components/auth/RegisterModal.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@mui/material';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -5,6 +6,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
+import { useNavigate } from 'react-router-dom';
 
 interface RegisterModalProps {
   isOpen: boolean;
@@ -12,6 +14,7 @@ interface RegisterModalProps {
 }
 
 export default function RegisterModal({ isOpen, onClose }: RegisterModalProps) {
+  const navigate = useNavigate();
   const handleClose = (isSuccess: boolean = false) => {
     if (typeof onClose === 'function') onClose(isSuccess);
   };
@@ -31,14 +34,7 @@ export default function RegisterModal({ isOpen, onClose }: RegisterModalProps) {
             variant="standard"
           />
 
-          <TextField
-            fullWidth
-            margin="dense"
-            id="password"
-            label="비밀번호"
-            type="password"
-            variant="standard"
-          />
+          <TextField fullWidth margin="dense" id="password" label="비밀번호" type="password" variant="standard" />
 
           <TextField
             fullWidth
@@ -49,19 +45,18 @@ export default function RegisterModal({ isOpen, onClose }: RegisterModalProps) {
             variant="standard"
           />
 
-          <TextField
-            fullWidth
-            margin="dense"
-            id="name"
-            label="이름"
-            type="name"
-            variant="standard"
-          />
+          <TextField fullWidth margin="dense" id="name" label="이름" type="name" variant="standard" />
 
           <DialogContentText>
             <small>
               계정이 이미 있으신가요?{' '}
-              <span className="link">로그인하러 가기</span>
+              <Link
+                onClick={() => navigate('/login')}
+                component="button"
+                sx={{ color: 'inherit', textDecorationColor: 'inherit', fontWeight: 500, verticalAlign: 'baseline' }}
+              >
+                로그인하러 가기
+              </Link>
             </small>
           </DialogContentText>
         </DialogContent>

--- a/client/src/pub/PublishRouter.tsx
+++ b/client/src/pub/PublishRouter.tsx
@@ -10,12 +10,9 @@ import RecruitAddPage from '@/pages/recruits/RecruitAddPage';
 import RecruitDetailPage from '@/pages/recruits/RecruitDetailPage';
 import RecruitEditPage from '@/pages/recruits/RecruitEditPage';
 import PublishList from '@/pub/PublishList';
-import {
-  Navigate,
-  Route,
-  BrowserRouter as Router,
-  Routes,
-} from 'react-router-dom';
+
+import { Navigate, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import PrivateRoute from '@/utils/PrivateRoute';
 
 const PublishRouter = () => {
   return (
@@ -30,8 +27,10 @@ const PublishRouter = () => {
         <Route path="/loading" element={<LoadingPage />} />
 
         {/* 인증 */}
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
+        <Route element={<PrivateRoute authentication="LOGOUT" />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+        </Route>
 
         {/* 홈 */}
         <Route path="/home" element={<HomePage />} />

--- a/client/src/utils/PrivateRoute.tsx
+++ b/client/src/utils/PrivateRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+// 추후 유저 타입 별 페이지 접근권한 부여
+type UserRole = 'admin' | 'developer' | 'employer';
+
+interface PrivateRouteProps {
+  authentication: 'LOGIN' | 'LOGOUT' | UserRole;
+}
+
+export default function PrivateRoute({ authentication }: PrivateRouteProps): React.ReactElement {
+  const isAuthenticated = !!window.sessionStorage.getItem('token');
+
+  switch (authentication) {
+    case 'LOGOUT': // 로그인 하지 않은 상태
+      return isAuthenticated ? <Navigate to="/" /> : <Outlet />;
+    case 'LOGIN': // 로그인 한 상태
+      return isAuthenticated ? <Outlet /> : <Navigate to="/login" />;
+    default:
+      return <Outlet />;
+  }
+}

--- a/client/src/utils/errorHandling.ts
+++ b/client/src/utils/errorHandling.ts
@@ -1,0 +1,20 @@
+import { AxiosError, AxiosResponse } from 'axios';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const formatCustomError = (response: AxiosResponse<any, any>) => {
+  const customError: AxiosError = {
+    message: response.data.message,
+    name: 'CustomError',
+    request: {
+      ...response.request,
+      status: response.data.status || 500,
+      statusText: response.data.statusText || 'CUSTOM_ERROR',
+    },
+    code: response.data.code || 'CUSTOM_ERR_BAD_RESPONSE',
+    isAxiosError: true,
+    toJSON: function (): object {
+      throw new Error('Function not implemented.');
+    },
+  };
+  return Promise.reject(customError);
+};


### PR DESCRIPTION
### 에러핸들링
임시구현된 서버에서 오는 응답 중 false 응답을 axios에러로 처리할 수 있도록 에러핸들링을 임시구현하였습니다.
에러로 반환되지 않도록 의도하신 것이라면 사용하지 않도록 하겠습니다.


### 유저로그인
input 태그로 최소한의 validation을 구현하였고, 로그인 실패시 서버의 에러메시지를 보여주도록 하였습니다.


### 접근 권한 유틸
로그인 시 토큰을 세션스토리지에서 관리하도록 하였고, 토큰 여부에 따라서 페이지 접근권한을 관리할 수 있는 private route를 구현하였습니다. 이후 서버에서 토큰을 구현한다면 토큰 유효시간 검증로직도 추가할 예정입니다.